### PR TITLE
Holding ALT key while clicking item in inventory causes damage to be rolled as a crit

### DIFF
--- a/scripts/itemOverrides.js
+++ b/scripts/itemOverrides.js
@@ -288,6 +288,9 @@ async function rollItem({
       const autoRollDamage = game.settings.get(moduleName, SETTING_AUTO_ROLL_DAMAGE);
       const spellLevel = $(message.data.content).data('spell-level') || null;
 
+      // Don't roll as a crit if it's rolling from the item
+      event.altKey = false;
+
       switch (autoRollDamage) {
         case AUTO_ROLL_DAMAGE_DM_ONLY:
           if (ownedOnlyByGM(this.actor)) {


### PR DESCRIPTION
Resolves #11 